### PR TITLE
[Feat/update-swagger-parameter]

### DIFF
--- a/src/main/java/org/runimo/runimo/user/controller/UserId.java
+++ b/src/main/java/org/runimo/runimo/user/controller/UserId.java
@@ -1,5 +1,6 @@
 package org.runimo.runimo.user.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.lang.annotation.ElementType;
@@ -10,5 +11,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 @Schema(description = "JWT 토큰 내 사용자 ID")
+@Parameter(hidden = true)
 public @interface UserId {
 }


### PR DESCRIPTION
- userId는 jwt토큰을 통해 추출하는 값으로 스프링 ArgumentResolver가 처리함.
- 스웨거는 컨트롤러 메소드의 변수를 기본적으로 노출하는데, 이는 노출되지 않는 변수까지 표시해 혼란을 야기함.

- 어노테이션에 hidden 옵션을 추가하여 해결