### PR TITLE
[Fix/ fix base64 encoding error]

### DIFF
--- a/src/main/java/org/runimo/runimo/auth/service/apple/AppleTokenVerifier.java
+++ b/src/main/java/org/runimo/runimo/auth/service/apple/AppleTokenVerifier.java
@@ -153,14 +153,14 @@ public class AppleTokenVerifier {
       long expMillis = nowMillis + 180L * 24 * 60 * 60 * 1000; // 180일
 
       // 개인 키 포맷팅 및 디코딩
-      String formattedKey = "-----BEGIN PRIVATE KEY-----\n" + applePrivateKey.replace("\\\\n", "\n")
-          .trim() + "\n-----END PRIVATE KEY-----";
+      String privateKeyContent = applePrivateKey.replace("\\n", "").trim();
+      String formattedKey = "-----BEGIN PRIVATE KEY-----\n" + privateKeyContent + "\n-----END PRIVATE KEY-----";
 
       byte[] decodedKey = Base64.getDecoder().decode(
           formattedKey
               .replace("-----BEGIN PRIVATE KEY-----", "")
               .replace("-----END PRIVATE KEY-----", "")
-              .replace("\\s", "")
+              .replaceAll("\\s", "") // 모든 공백 문자 제거
       );
 
       // 개인 키 생성


### PR DESCRIPTION
### 작업내역

![Screenshot 2025-04-08 at 11 29 08 AM](https://github.com/user-attachments/assets/5a2add19-e60c-47b1-9e06-f92a87a5094f)

- Client Secret을 만들기 위해 애플의 표준 규격으로 문자열을 생성하는 과정에서 문제가 발생했습니다.

- `\\s` 정규식으로 문자를 바꾸려면 `replaceAll()` 함수를 사용해야합니다. 또한 `\\\n` 은 String literal `\n`을 찾기에 문제가 있었습니다.