### PR TITLE
[Fix/fix-common-responses] - Jackson Binding을 위한 기본생성자

### DIFF
--- a/src/main/java/org/runimo/runimo/common/response/ErrorResponse.java
+++ b/src/main/java/org/runimo/runimo/common/response/ErrorResponse.java
@@ -1,17 +1,16 @@
 package org.runimo.runimo.common.response;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.runimo.runimo.exceptions.code.CustomResponseCode;
 
 @ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse extends Response {
 
-    private ErrorResponse(final String errorMessage, final String errorCode) {
+    protected ErrorResponse(final String errorMessage, final String errorCode) {
         super(false, errorMessage, errorCode);
-    }
-
-    private ErrorResponse(final CustomResponseCode errorCode) {
-        super(false, errorCode);
     }
 
     public static ErrorResponse of(final String errorMessage, final String errorCode) {
@@ -19,7 +18,7 @@ public class ErrorResponse extends Response {
     }
 
     public static ErrorResponse of(final CustomResponseCode errorCode) {
-        return new ErrorResponse(errorCode);
+        return new ErrorResponse(errorCode.getClientMessage(), errorCode.getCode());
     }
 }
 

--- a/src/main/java/org/runimo/runimo/common/response/Response.java
+++ b/src/main/java/org/runimo/runimo/common/response/Response.java
@@ -1,20 +1,23 @@
 package org.runimo.runimo.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.runimo.runimo.exceptions.code.CustomResponseCode;
 
 @ToString
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Response {
 
     @Schema(description = "성공 여부")
-    private final boolean success;
+    private boolean success;
     @Schema(description = "응답 메세지")
-    private final String message;
+    private String message;
     @Schema(description = "응답 코드")
-    private final String code;
+    private String code;
 
     protected Response(final boolean success, final String message, final String code) {
         this.success = success;

--- a/src/main/java/org/runimo/runimo/exceptions/RegisterErrorResponse.java
+++ b/src/main/java/org/runimo/runimo/exceptions/RegisterErrorResponse.java
@@ -1,16 +1,19 @@
 package org.runimo.runimo.exceptions;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import org.runimo.runimo.common.response.Response;
+import lombok.NoArgsConstructor;
+import org.runimo.runimo.common.response.ErrorResponse;
 import org.runimo.runimo.exceptions.code.CustomResponseCode;
 
 @Getter
-public class RegisterErrorResponse extends Response {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RegisterErrorResponse extends ErrorResponse {
 
-    private final String temporalRegisterToken;
+    private  String temporalRegisterToken;
 
     public RegisterErrorResponse(CustomResponseCode errorCode, String temporalRegisterToken) {
-        super(false, errorCode.getClientMessage(), errorCode.getCode());
+        super(errorCode.getClientMessage(), errorCode.getCode());
         this.temporalRegisterToken = temporalRegisterToken;
     }
 }


### PR DESCRIPTION
### 작업내역

- Jackson은 기본생성자 + getter, setter조합을 사용하여 매핑과 직렬화를합니다.
  - 기존 코드에서 final을 사용하여 기본생성자 없이사용했는데, 이 경우에는 생성자를 통해 바인딩을 하게됩니다. 따라서 의도치 않은 객체가 응답에 추가되는 오류가 발생했습니다. 
```json
{
  "errorCode": {
    "client_message": "string",
    "http_status_code": "CONTINUE",
    "log_message": "string",
    "code": "string"
  },
  "temporal_register_token": "string",
  "success": true,
  "message": "string",
  "code": "string"
}

```
- final을 지우고 기본생성자를 추가하여 Getter을 통한 매핑이 가능하도록 변경했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved flexibility of error and response handling, allowing for easier extension and integration with frameworks.
	- Adjusted internal structures to support mutable fields and enhanced subclassing capabilities for error responses.

- **Chores**
	- Updated constructors and inheritance for consistency across response-related classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->