### PR TITLE
[Feat/admin authorization] - 사용자 권한에 따른 시큐리티 설정

### DIFF
--- a/src/main/java/org/runimo/runimo/auth/exceptions/UnauthorizedAccessException.java
+++ b/src/main/java/org/runimo/runimo/auth/exceptions/UnauthorizedAccessException.java
@@ -1,0 +1,15 @@
+package org.runimo.runimo.auth.exceptions;
+
+import org.runimo.runimo.auth.filters.UserErrorCode;
+import org.runimo.runimo.exceptions.BusinessException;
+
+public class UnauthorizedAccessException extends BusinessException {
+
+    public UnauthorizedAccessException(String message) {
+        super(UserErrorCode.INSUFFICIENT_PERMISSIONS, message);
+    }
+
+    public UnauthorizedAccessException(Throwable cause) {
+        super(UserErrorCode.INSUFFICIENT_PERMISSIONS, cause.getMessage());
+    }
+}

--- a/src/main/java/org/runimo/runimo/auth/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/org/runimo/runimo/auth/filters/JwtAuthenticationFilter.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.runimo.runimo.auth.jwt.JwtResolver;
 import org.runimo.runimo.auth.jwt.UserDetail;
 import org.runimo.runimo.common.response.ErrorResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -39,6 +40,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
         throws IOException {
         try {
+
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.isAuthenticated() &&
+                !(auth instanceof AnonymousAuthenticationToken)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             if (!hasValidAuthorizationHeader(request)) {
                 setErrorResponse(UserErrorCode.JWT_NOT_FOUND, response);
                 return;

--- a/src/main/java/org/runimo/runimo/auth/filters/UserErrorCode.java
+++ b/src/main/java/org/runimo/runimo/auth/filters/UserErrorCode.java
@@ -16,6 +16,9 @@ public enum UserErrorCode implements CustomResponseCode {
     JWT_BROKEN("UEH4014", HttpStatus.UNAUTHORIZED, "JWT 토큰이 손상되었습니다", "JWT 토큰이 손상되었습니다"),
     REFRESH_FAILED("UEH4015", HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다.", "리프레시 토큰이 만료되었습니다."),
 
+    // 403
+    INSUFFICIENT_PERMISSIONS("UEH4031", HttpStatus.FORBIDDEN, "권한이 부족합니다.", "권한이 부족합니다."),
+
     // 404
     USER_NOT_FOUND("UEH4041", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없음", "사용자를 찾을 수 없음"),
     ;

--- a/src/main/java/org/runimo/runimo/config/SecurityConfig.java
+++ b/src/main/java/org/runimo/runimo/config/SecurityConfig.java
@@ -11,9 +11,11 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true) // 메서드 레벨 보안 활성화
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -30,6 +32,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/api/v1/auth/**").permitAll()
                 .requestMatchers("/api/v1/users/**").hasAnyRole("USER", "ADMIN")
+                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers("/checker/**").permitAll()
                 .requestMatchers("/actuator/**").permitAll()
                 .requestMatchers(("/error")).permitAll()
@@ -55,6 +58,7 @@ public class SecurityConfig {
                 .permitAll()
                 .requestMatchers(("/error")).permitAll()
                 .requestMatchers("/api/v1/users/**").hasAnyRole("USER", "ADMIN")
+                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers("/checker/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/org/runimo/runimo/config/SecurityConstants.java
+++ b/src/main/java/org/runimo/runimo/config/SecurityConstants.java
@@ -1,0 +1,29 @@
+package org.runimo.runimo.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class SecurityConstants {
+
+
+    static final String[] COMMON_PUBLIC_ENDPOINTS = {
+        "/api/v1/auth/**",
+        "/checker/**",
+        "/actuator/**",
+        "/error"
+    };
+
+    static final String[] DEV_PUBLIC_ENDPOINTS = {
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/v3/api-docs/**"
+    };
+
+    static final String ADMIN_ENDPOINT_PATTERN = "/api/v1/admin/**";
+
+    static final String USER_ENDPOINT_PATTERN = "/api/v1/users/**";
+
+    static final String USER_ROLE = "USER";
+    static final String ADMIN_ROLE = "ADMIN";
+}

--- a/src/main/java/org/runimo/runimo/exceptions/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/runimo/runimo/exceptions/CustomAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package org.runimo.runimo.exceptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.runimo.runimo.auth.filters.UserErrorCode;
+import org.runimo.runimo.common.response.ErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException {
+
+        log.warn("[ERROR]접근 거부됨 - URI: {}, 사용자: {}",
+            request.getRequestURI(),
+            SecurityContextHolder.getContext().getAuthentication().getName());
+        
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(UserErrorCode.INSUFFICIENT_PERMISSIONS);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/org/runimo/runimo/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/org/runimo/runimo/exceptions/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import jakarta.persistence.LockTimeoutException;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.runimo.runimo.auth.exceptions.SignUpException;
-import org.runimo.runimo.auth.exceptions.UnRegisteredUserException;
+import org.runimo.runimo.auth.exceptions.UnauthorizedAccessException;
 import org.runimo.runimo.auth.exceptions.UserJwtException;
 import org.runimo.runimo.common.response.ErrorResponse;
 import org.runimo.runimo.external.ExternalServiceException;
@@ -26,6 +26,14 @@ public class GlobalExceptionHandler {
 
     private static final String ERROR_LOG_HEADER = "ERROR: ";
 
+
+    @ExceptionHandler(UnauthorizedAccessException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedAccessException(
+        UnauthorizedAccessException e) {
+        log.debug("{} {}", ERROR_LOG_HEADER, e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(ErrorResponse.of(e.getErrorCode()));
+    }
 
     @ExceptionHandler(RunimoException.class)
     public ResponseEntity<ErrorResponse> handleRunimoException(RunimoException e) {

--- a/src/main/java/org/runimo/runimo/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/org/runimo/runimo/exceptions/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -26,6 +27,14 @@ public class GlobalExceptionHandler {
 
     private static final String ERROR_LOG_HEADER = "ERROR: ";
 
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
+        NoResourceFoundException e) {
+        log.warn("{} {}", ERROR_LOG_HEADER, e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse.of("요청한 리소스를 찾을 수 없습니다.", e.getMessage()));
+    }
 
     @ExceptionHandler(UnauthorizedAccessException.class)
     public ResponseEntity<ErrorResponse> handleUnauthorizedAccessException(


### PR DESCRIPTION
### 작업 내역

시큐리티 Config 수정 및 리팩토링

- `/api/v1/admin`에 대한 url기반 권한 필터링 추가 : https://github.com/Run-Us/Runimo/commit/aec6b400b52421d22a687a6c045a93dc0cae9650
- 중복되는 코드 추출, 환경 (prod, dev, test)에 따른 시큐리티 설정 메소드 분리 : https://github.com/Run-Us/Runimo/commit/897b1387585ba3cf5d7674e37bc606b34b918984
- 엔드포인트 String 리터럴 SecurityConstants 클래스에 선언, package-private 공개

에러코드 추가
- UserErrorCode에 권한 에러 추가 HTTP 403
- UnauthorizedAccessException 추가

핸들러 추가
- NoResourceFound 404 추가
- UnauthorizedAccessException 핸들러 추가 `/common/config/CustomAuthenticationFailureHander`

**jwt 필터에 AuthContext가 존재하면 필터링 넘어가도록 설정** : https://github.com/Run-Us/Runimo/commit/f8fd1957fe65be16274529fd8e953a5b4258a242
- 러니모 서비스는 전체 회원-전용 서비스라서 모든 API에  Authorization-헤더를 요구함.
  - 기존 테스트에서도 직접 헤더에 토큰을 주입했었음. << pain point
  - 테스트에서 일일이 JWT를 넣지않고 `@WithMockUser`을 사용해도 실행되도록 설정


