### PR TITLE
[Feat/user device token] - 알림을 위한 디바이스 토큰수집

### DIFF
--- a/src/main/java/org/runimo/runimo/auth/controller/request/AuthSignupRequest.java
+++ b/src/main/java/org/runimo/runimo/auth/controller/request/AuthSignupRequest.java
@@ -2,23 +2,62 @@ package org.runimo.runimo.auth.controller.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.runimo.runimo.auth.service.dto.UserSignupCommand;
+import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.Gender;
 import org.springframework.web.multipart.MultipartFile;
 
 @Schema(description = "사용자 회원가입 요청 DTO")
-public record AuthSignupRequest(
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AuthSignupRequest {
+
     @Schema(description = "회원가입용 임시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI...")
-    @NotBlank String registerToken,
+    @NotBlank(message = "회원가입 토큰은 필수입니다")
+    private String registerToken;
 
     @Schema(description = "사용자 닉네임", example = "RunimoUser")
-    @NotBlank String nickname,
+    @NotBlank
+    String nickname;
 
     @Schema(description = "성별", example = "FEMALE")
-    Gender gender
-) {
+    private Gender gender;
+
+    @Schema(description = "디바이스 토큰", example = "string")
+    private String deviceToken;
+
+    @Schema(description = "디바이스 플랫폼", example = "FCM / APNS")
+    private String devicePlatform;
+
+    public AuthSignupRequest(String registerToken, String nickname, Gender gender) {
+        this.registerToken = registerToken;
+        this.nickname = nickname;
+        this.gender = gender;
+    }
 
     public UserSignupCommand toUserSignupCommand(MultipartFile file) {
-        return new UserSignupCommand(registerToken, nickname, file, gender);
+        if (hasDeviceToken() && (devicePlatform == null || devicePlatform.trim().isEmpty())) {
+            throw new IllegalArgumentException("디바이스 토큰이 있으면 플랫폼도 필수입니다.");
+        }
+        return new UserSignupCommand(
+            registerToken,
+            nickname,
+            file,
+            gender,
+            deviceToken,
+            devicePlatform != null ? DevicePlatform.fromString(devicePlatform) : null
+        );
+    }
+
+    private boolean hasDeviceToken() {
+        return deviceToken != null && !deviceToken.trim().isEmpty();
     }
 }

--- a/src/main/java/org/runimo/runimo/auth/service/dto/UserSignupCommand.java
+++ b/src/main/java/org/runimo/runimo/auth/service/dto/UserSignupCommand.java
@@ -1,6 +1,7 @@
 package org.runimo.runimo.auth.service.dto;
 
 
+import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.Gender;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -8,7 +9,9 @@ public record UserSignupCommand(
     String registerToken,
     String nickname,
     MultipartFile profileImage,
-    Gender gender
+    Gender gender,
+    String deviceToken,
+    DevicePlatform devicePlatform
 ) {
 
 }

--- a/src/main/java/org/runimo/runimo/user/domain/DevicePlatform.java
+++ b/src/main/java/org/runimo/runimo/user/domain/DevicePlatform.java
@@ -1,0 +1,11 @@
+package org.runimo.runimo.user.domain;
+
+public enum DevicePlatform {
+    FCM,
+    APNS;
+
+
+    public static DevicePlatform fromString(String value) {
+        return DevicePlatform.valueOf(value.toUpperCase());
+    }
+}

--- a/src/main/java/org/runimo/runimo/user/domain/DevicePlatform.java
+++ b/src/main/java/org/runimo/runimo/user/domain/DevicePlatform.java
@@ -2,7 +2,8 @@ package org.runimo.runimo.user.domain;
 
 public enum DevicePlatform {
     FCM,
-    APNS;
+    APNS,
+    NONE;
 
 
     public static DevicePlatform fromString(String value) {

--- a/src/main/java/org/runimo/runimo/user/domain/UserDeviceToken.java
+++ b/src/main/java/org/runimo/runimo/user/domain/UserDeviceToken.java
@@ -1,0 +1,60 @@
+package org.runimo.runimo.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.runimo.runimo.common.CreateUpdateAuditEntity;
+
+@Table(name = "user_token")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserDeviceToken extends CreateUpdateAuditEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(name = "device_token", nullable = false)
+    private String deviceToken;
+
+    @Column(name = "platform", nullable = false)
+    private DevicePlatform platform;
+
+    @Column(name = "notification_allowed", nullable = false)
+    private Boolean notificationAllowed;
+
+    @Column(name = "last_used_at")
+    private LocalDateTime lastUsedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public static UserDeviceToken from(String deviceToken, DevicePlatform platform,
+        Boolean notificationAllowed) {
+        return UserDeviceToken.builder()
+            .deviceToken(deviceToken)
+            .notificationAllowed(notificationAllowed)
+            .platform(platform)
+            .build();
+    }
+
+}

--- a/src/main/java/org/runimo/runimo/user/repository/UserDeviceTokenRepository.java
+++ b/src/main/java/org/runimo/runimo/user/repository/UserDeviceTokenRepository.java
@@ -1,0 +1,10 @@
+package org.runimo.runimo.user.repository;
+
+import org.runimo.runimo.user.domain.UserDeviceToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserDeviceTokenRepository extends JpaRepository<UserDeviceToken, Long> {
+
+}

--- a/src/main/java/org/runimo/runimo/user/service/UserCreator.java
+++ b/src/main/java/org/runimo/runimo/user/service/UserCreator.java
@@ -1,12 +1,15 @@
 package org.runimo.runimo.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.LovePoint;
 import org.runimo.runimo.user.domain.OAuthInfo;
 import org.runimo.runimo.user.domain.SocialProvider;
 import org.runimo.runimo.user.domain.User;
+import org.runimo.runimo.user.domain.UserDeviceToken;
 import org.runimo.runimo.user.repository.LovePointRepository;
 import org.runimo.runimo.user.repository.OAuthInfoRepository;
+import org.runimo.runimo.user.repository.UserDeviceTokenRepository;
 import org.runimo.runimo.user.repository.UserRepository;
 import org.runimo.runimo.user.service.dto.command.UserCreateCommand;
 import org.springframework.stereotype.Component;
@@ -19,6 +22,7 @@ public class UserCreator {
     private final UserRepository userRepository;
     private final OAuthInfoRepository oAuthInfoRepository;
     private final LovePointRepository lovePointRepository;
+    private final UserDeviceTokenRepository userDeviceTokenRepository;
 
     @Transactional
     public User createUser(UserCreateCommand command) {
@@ -47,5 +51,17 @@ public class UserCreator {
             .amount(0L)
             .build();
         return lovePointRepository.save(lovePoint);
+    }
+
+    @Transactional
+    public UserDeviceToken createUserDeviceToken(User user, String deviceToken,
+        DevicePlatform platform) {
+        UserDeviceToken userDeviceToken = UserDeviceToken.builder()
+            .user(user)
+            .deviceToken(deviceToken)
+            .platform(platform)
+            .notificationAllowed(true)
+            .build();
+        return userDeviceTokenRepository.save(userDeviceToken);
     }
 }

--- a/src/main/java/org/runimo/runimo/user/service/UserCreator.java
+++ b/src/main/java/org/runimo/runimo/user/service/UserCreator.java
@@ -1,7 +1,6 @@
 package org.runimo.runimo.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.LovePoint;
 import org.runimo.runimo.user.domain.OAuthInfo;
 import org.runimo.runimo.user.domain.SocialProvider;
@@ -11,6 +10,7 @@ import org.runimo.runimo.user.repository.LovePointRepository;
 import org.runimo.runimo.user.repository.OAuthInfoRepository;
 import org.runimo.runimo.user.repository.UserDeviceTokenRepository;
 import org.runimo.runimo.user.repository.UserRepository;
+import org.runimo.runimo.user.service.dto.command.DeviceTokenDto;
 import org.runimo.runimo.user.service.dto.command.UserCreateCommand;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,14 +54,16 @@ public class UserCreator {
     }
 
     @Transactional
-    public UserDeviceToken createUserDeviceToken(User user, String deviceToken,
-        DevicePlatform platform) {
+    public void createUserDeviceToken(User user, DeviceTokenDto deviceTokenDto) {
+        if (deviceTokenDto.isEmpty()) {
+            return;
+        }
         UserDeviceToken userDeviceToken = UserDeviceToken.builder()
             .user(user)
-            .deviceToken(deviceToken)
-            .platform(platform)
+            .deviceToken(deviceTokenDto.token())
+            .platform(deviceTokenDto.platform())
             .notificationAllowed(true)
             .build();
-        return userDeviceTokenRepository.save(userDeviceToken);
+        userDeviceTokenRepository.save(userDeviceToken);
     }
 }

--- a/src/main/java/org/runimo/runimo/user/service/UserRegisterService.java
+++ b/src/main/java/org/runimo/runimo/user/service/UserRegisterService.java
@@ -26,8 +26,7 @@ public class UserRegisterService {
         userCreator.createUserOAuthInfo(savedUser, command.socialProvider(), command.providerId());
         userCreator.createLovePoint(savedUser.getId());
         userItemCreator.createAll(savedUser.getId());
-        userCreator.createUserDeviceToken(savedUser, command.deviceToken(),
-            command.devicePlatform());
+        userCreator.createUserDeviceToken(savedUser, command.deviceToken());
         return savedUser;
     }
 

--- a/src/main/java/org/runimo/runimo/user/service/UserRegisterService.java
+++ b/src/main/java/org/runimo/runimo/user/service/UserRegisterService.java
@@ -26,6 +26,8 @@ public class UserRegisterService {
         userCreator.createUserOAuthInfo(savedUser, command.socialProvider(), command.providerId());
         userCreator.createLovePoint(savedUser.getId());
         userItemCreator.createAll(savedUser.getId());
+        userCreator.createUserDeviceToken(savedUser, command.deviceToken(),
+            command.devicePlatform());
         return savedUser;
     }
 

--- a/src/main/java/org/runimo/runimo/user/service/dto/command/DeviceTokenDto.java
+++ b/src/main/java/org/runimo/runimo/user/service/dto/command/DeviceTokenDto.java
@@ -1,0 +1,19 @@
+package org.runimo.runimo.user.service.dto.command;
+
+import org.runimo.runimo.user.domain.DevicePlatform;
+
+public record DeviceTokenDto(String token, DevicePlatform platform) {
+
+    public static final DeviceTokenDto EMPTY = new DeviceTokenDto("", null);
+
+    public static DeviceTokenDto of(String deviceToken, DevicePlatform devicePlatform) {
+        if (deviceToken == null || deviceToken.isEmpty()) {
+            return EMPTY;
+        }
+        return new DeviceTokenDto(deviceToken, devicePlatform);
+    }
+
+    public boolean isEmpty() {
+        return this == EMPTY;
+    }
+}

--- a/src/main/java/org/runimo/runimo/user/service/dto/command/DeviceTokenDto.java
+++ b/src/main/java/org/runimo/runimo/user/service/dto/command/DeviceTokenDto.java
@@ -4,10 +4,11 @@ import org.runimo.runimo.user.domain.DevicePlatform;
 
 public record DeviceTokenDto(String token, DevicePlatform platform) {
 
-    public static final DeviceTokenDto EMPTY = new DeviceTokenDto("", null);
+    public static final DeviceTokenDto EMPTY = new DeviceTokenDto("", DevicePlatform.NONE);
 
     public static DeviceTokenDto of(String deviceToken, DevicePlatform devicePlatform) {
-        if (deviceToken == null || deviceToken.isEmpty()) {
+        if (deviceToken == null || deviceToken.isEmpty() || devicePlatform == null
+            || devicePlatform == DevicePlatform.NONE) {
             return EMPTY;
         }
         return new DeviceTokenDto(deviceToken, devicePlatform);

--- a/src/main/java/org/runimo/runimo/user/service/dto/command/UserRegisterCommand.java
+++ b/src/main/java/org/runimo/runimo/user/service/dto/command/UserRegisterCommand.java
@@ -1,6 +1,7 @@
 package org.runimo.runimo.user.service.dto.command;
 
 import jakarta.validation.constraints.NotNull;
+import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.Gender;
 import org.runimo.runimo.user.domain.SocialProvider;
 
@@ -9,7 +10,9 @@ public record UserRegisterCommand(
     String imgUrl,
     Gender gender,
     @NotNull String providerId,
-    @NotNull SocialProvider socialProvider
+    @NotNull SocialProvider socialProvider,
+    String deviceToken,
+    DevicePlatform devicePlatform
 ) {
 
 }

--- a/src/main/java/org/runimo/runimo/user/service/dto/command/UserRegisterCommand.java
+++ b/src/main/java/org/runimo/runimo/user/service/dto/command/UserRegisterCommand.java
@@ -1,7 +1,6 @@
 package org.runimo.runimo.user.service.dto.command;
 
 import jakarta.validation.constraints.NotNull;
-import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.Gender;
 import org.runimo.runimo.user.domain.SocialProvider;
 
@@ -11,8 +10,7 @@ public record UserRegisterCommand(
     Gender gender,
     @NotNull String providerId,
     @NotNull SocialProvider socialProvider,
-    String deviceToken,
-    DevicePlatform devicePlatform
+    DeviceTokenDto deviceToken
 ) {
 
 }

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -37,11 +37,15 @@ CREATE TABLE `users`
 
 CREATE TABLE `user_token`
 (
-    `user_id`      BIGINT       NOT NULL,
-    `device_token` VARCHAR(255) NOT NULL,
-    `created_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    `updated_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    `deleted_at`   TIMESTAMP    NULL,
+    `id`                   BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL,
+    `user_id`              BIGINT                            NOT NULL,
+    `device_token`         VARCHAR(255)                      NOT NULL,
+    `platform`             ENUM ('FCM', 'APNS')              NOT NULL DEFAULT 'APNS',
+    `notification_allowed` BOOLEAN                           NOT NULL DEFAULT TRUE,
+    `last_used_at`         TIMESTAMP                                  DEFAULT CURRENT_TIMESTAMP,
+    `created_at`           TIMESTAMP                                  DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`           TIMESTAMP                                  DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`           TIMESTAMP                         NULL,
 
     FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
 );

--- a/src/test/java/org/runimo/runimo/auth/service/SignUpUsecaseTest.java
+++ b/src/test/java/org/runimo/runimo/auth/service/SignUpUsecaseTest.java
@@ -25,6 +25,7 @@ import org.runimo.runimo.external.FileStorageService;
 import org.runimo.runimo.item.EggFixtures;
 import org.runimo.runimo.rewards.service.eggs.EggGrantService;
 import org.runimo.runimo.user.UserFixtures;
+import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.Gender;
 import org.runimo.runimo.user.domain.SocialProvider;
 import org.runimo.runimo.user.enums.UserHttpResponseCode;
@@ -81,7 +82,8 @@ class SignUpUsecaseTest {
         when(jwtTokenFactory.generateTokenPair(any())).thenReturn(UserFixtures.TEST_TOKEN_PAIR);
 
         SignupUserResponse response = sut
-            .register(new UserSignupCommand(registerToken, "nickname", null, Gender.UNKNOWN));
+            .register(new UserSignupCommand(registerToken, "nickname", null, Gender.UNKNOWN,
+                "device_token", DevicePlatform.APNS));
 
         assertEquals(1L, response.userId());
         assertEquals(UserFixtures.TEST_USER_NICKNAME, response.nickname());
@@ -110,7 +112,8 @@ class SignUpUsecaseTest {
             .validateExistingUser(payload.providerId(), payload.socialProvider());
 
         assertThrows(SignUpException.class, () -> {
-            sut.register(new UserSignupCommand(registerToken, "nickname", null, Gender.UNKNOWN));
+            sut.register(new UserSignupCommand(registerToken, "nickname", null, Gender.UNKNOWN,
+                "device_token", DevicePlatform.APNS));
         });
     }
 }

--- a/src/test/java/org/runimo/runimo/rewards/RewardTest.java
+++ b/src/test/java/org/runimo/runimo/rewards/RewardTest.java
@@ -23,6 +23,7 @@ import org.runimo.runimo.records.service.usecases.dtos.RecordSaveResponse;
 import org.runimo.runimo.rewards.service.RewardService;
 import org.runimo.runimo.rewards.service.dto.RewardClaimCommand;
 import org.runimo.runimo.rewards.service.dto.RewardResponse;
+import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.Gender;
 import org.runimo.runimo.user.domain.SocialProvider;
 import org.runimo.runimo.user.domain.User;
@@ -74,8 +75,9 @@ class RewardTest {
             null,
             SocialProvider.KAKAO
         ));
-        UserSignupCommand command = new UserSignupCommand(registerToken, "name", null,
-            Gender.UNKNOWN);
+        UserSignupCommand command = new UserSignupCommand(registerToken, "nickname", null,
+            Gender.UNKNOWN,
+            "device_token", DevicePlatform.APNS);
         Long useId = signUpUsecaseImpl.register(command).userId();
         savedUser = userRepository.findById(useId).orElse(null);
     }

--- a/src/test/java/org/runimo/runimo/user/api/UserItemAcceptanceTest.java
+++ b/src/test/java/org/runimo/runimo/user/api/UserItemAcceptanceTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 import static org.runimo.runimo.TestConsts.TEST_USER_UUID;
+import static org.runimo.runimo.user.domain.DevicePlatform.APNS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -153,7 +154,9 @@ class UserItemAcceptanceTest {
         AuthSignupRequest request = new AuthSignupRequest(
             registerToken,
             "test-user",
-            Gender.FEMALE
+            Gender.FEMALE,
+            "device_token",
+            APNS.name()
         );
 
         ValidatableResponse res = given()

--- a/src/test/java/org/runimo/runimo/user/service/usecases/UserRegisterServiceTest.java
+++ b/src/test/java/org/runimo/runimo/user/service/usecases/UserRegisterServiceTest.java
@@ -13,12 +13,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.runimo.runimo.user.domain.DevicePlatform;
 import org.runimo.runimo.user.domain.Gender;
 import org.runimo.runimo.user.domain.SocialProvider;
 import org.runimo.runimo.user.domain.User;
 import org.runimo.runimo.user.service.UserCreator;
 import org.runimo.runimo.user.service.UserItemCreator;
 import org.runimo.runimo.user.service.UserRegisterService;
+import org.runimo.runimo.user.service.dto.command.DeviceTokenDto;
 import org.runimo.runimo.user.service.dto.command.UserRegisterCommand;
 
 class UserRegisterServiceTest {
@@ -47,7 +49,8 @@ class UserRegisterServiceTest {
                 "https://test.com",
                 Gender.UNKNOWN,
                 providerId,
-                SocialProvider.KAKAO
+                SocialProvider.KAKAO,
+                DeviceTokenDto.of("example-device-token", DevicePlatform.APNS)
             );
         User mockUser = mock(User.class);
         when(userCreator.createUser(any())).thenReturn(mockUser);

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -35,13 +35,18 @@ CREATE TABLE `users`
     `deleted_at`               TIMESTAMP   NULL
 );
 
+
 CREATE TABLE `user_token`
 (
-    `user_id`      BIGINT       NOT NULL,
-    `device_token` VARCHAR(255) NOT NULL,
-    `created_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    `updated_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    `deleted_at`   TIMESTAMP    NULL,
+    `id`                   BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL,
+    `user_id`              BIGINT                            NOT NULL,
+    `device_token`         VARCHAR(255)                      NOT NULL,
+    `platform`             ENUM ('FCM', 'APNS')              NOT NULL DEFAULT 'APNS',
+    `notification_allowed` BOOLEAN                           NOT NULL DEFAULT TRUE,
+    `last_used_at`         TIMESTAMP                                  DEFAULT CURRENT_TIMESTAMP,
+    `created_at`           TIMESTAMP                                  DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`           TIMESTAMP                                  DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`           TIMESTAMP                         NULL,
 
     FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
 );


### PR DESCRIPTION
### 작업 내역

#### 디바이스 토큰 엔티티 추가
- `UserDeviceToken` 엔티티 추가 : https://github.com/Run-Us/Runimo/commit/2acf56cde09c06586b43f6af6a54abd63c9f61d1
- `src/resources/sql/schema.sql` 수정

#### 하위 호환성
- 기존 회원가입 API에서 토큰 필드 추가 (nullable) : https://github.com/Run-Us/Runimo/commit/92989728a0faeae4bfba78fd7b53e6a4eb4fda20
- 토큰 존재 시 저장 로직 작성
- 테스트 코드 작성

### 리뷰해주세요
- Entity 컬럼명 확인해주세요
- 회의에서 이야기했던 방향대로 `user_token` 테이블에 상태 컬럼을 두었어요! 확인부탁드립니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for registering device tokens and specifying device platforms (FCM or APNS) during user signup.
  - Device tokens are now stored and managed for each user, enabling improved notification handling.
- **Bug Fixes**
  - Signup now validates that a device platform is provided if a device token is submitted, returning an error otherwise.
- **Database**
  - Updated the user token table schema to include device platform, notification settings, and usage timestamps.
- **Tests**
  - Enhanced test coverage for signup scenarios involving device tokens and platforms, including validation and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->